### PR TITLE
add example env file and update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 node_modules
 minty-deployment.json
+config/default.env
 
 #Hardhat files
 cache

--- a/README.md
+++ b/README.md
@@ -149,10 +149,12 @@ minty pin 1
 > 🌿 Pinned all data for token id 1
 ```
 
-The `pin` command looks for a JWT access token from [Pinata](https://pinata.cloud) in the `PINATA_API_TOKEN` environment variable. Once you've obtained a token from Pinata, you can set it with a command like:
+The `pin` command looks for a JWT access token from [Pinata](https://pinata.cloud) in the `PINATA_API_TOKEN` environment variable. Once you've obtained a token from Pinata, make a file in the `config` directory called `default.env`, and edit it to look like this, with your JWT token inside the quote marks:
 
 ```shell
-export PINATA_API_TOKEN="paste token here"
+PINATA_API_TOKEN="Paste your Pinata JWT token inside the quotes!"
 ```
+
+Now Minty will be able to pin things to your Pinata account!
 
 If you'd prefer to use a different pinning service, you can edit the configuration in `config/default.js`.

--- a/config/default.env.example
+++ b/config/default.env.example
@@ -1,0 +1,1 @@
+PINATA_API_TOKEN="Paste your Pinata JWT token inside the quotes!"


### PR DESCRIPTION
This updates the readme to show how you can save your pinata token to a `default.env` file and have it be picked up by minty.

It also adds that file to `.gitignore` so people don't accidentally check their tokens into git, and adds a `default.env.example` file that can be copied over and filled in with a real key.