### PR TITLE
fix: broken URIs starting with ipfs://ipfs

### DIFF
--- a/src/minty.js
+++ b/src/minty.js
@@ -493,10 +493,15 @@ class Minty {
 }
 
 function ensureIpfsUriPrefix(cidOrURI) {
-    if (!cidOrURI.toString().startsWith('ipfs://')) {
-        return 'ipfs://' + cidOrURI
+    let uri = cidOrURI.toString()
+    if (!uri.startsWith('ipfs://')) {
+        uri = 'ipfs://' + cidOrURI
     }
-    return cidOrURI.toString()
+    // Avoid the Nyan Cat bug (https://github.com/ipfs/go-ipfs/pull/7930)
+    if (uri.startsWith('ipfs://ipfs/')) {
+      uri = uri.replace('ipfs://ipfs/', 'ipfs://')
+    }
+    return uri
 }
 
 /**


### PR DESCRIPTION
@yusefnapora this PR ensures we don't contribute to problem described in: https://github.com/ipfs/go-ipfs/pull/7930 
I did not run it, but should be a good starting point (feel free to edit this PR).