### PR TITLE
feat: produce CIDv1

### DIFF
--- a/src/minty.js
+++ b/src/minty.js
@@ -16,6 +16,11 @@ const { loadDeploymentInfo } = require('./deploy')
 // different environments (e.g. testnet, mainnet, staging, production, etc).
 const config = require('getconfig')
 
+// ipfs.add parameters for more deterministic CIDs
+const ipfsAddOptions = {
+  cidVersion: 1,
+  hashAlg: 'sha2-256'
+}
 
 /**
  * Construct and asynchronously initialize a new Minty instance.
@@ -101,14 +106,14 @@ class Minty {
         // 'ipfs://QmaNZ2FCgvBPqnxtkbToVVbK2Nes6xk5K4Ns6BsmkPucAM/cat-pic.png' instead of
         // 'ipfs://QmaNZ2FCgvBPqnxtkbToVVbK2Nes6xk5K4Ns6BsmkPucAM'
         const ipfsPath = '/nft/' + basename
-        const { cid: assetCid } = await this.ipfs.add({ path: ipfsPath, content })
+        const { cid: assetCid } = await this.ipfs.add({ path: ipfsPath, content }, ipfsAddOptions)
 
         // make the NFT metadata JSON
         const assetURI = ensureIpfsUriPrefix(assetCid) + '/' + basename
         const metadata = await this.makeNFTMetadata(assetURI, options)
 
         // add the metadata to IPFS
-        const { cid: metadataCid } = await this.ipfs.add({ path: '/nft/metadata.json', content: JSON.stringify(metadata)} )
+        const { cid: metadataCid } = await this.ipfs.add({ path: '/nft/metadata.json', content: JSON.stringify(metadata)}, ipfsAddOptions)
         const metadataURI = ensureIpfsUriPrefix(metadataCid) + '/metadata.json'
 
         // get the address of the token owner from options, or use the default signing address if no owner is given


### PR DESCRIPTION


This PR ensures produced CIDs are more deterministic and future-proof.


### Rationale 

We should avoid CIDv0 in blockchain contexts because it means people can cut corners and code against Multihash spec instead of CID spec.

Producing CIDv1 removes ambiguity and ensures people write things in a future-proof way. 
Also, UX is better: 
- the text representation is base32, so it looks the same on subdomain gateways and in browser address bar
- works even in user agents that force-lowercase on the authority part of URIs (and avoids errors like https://github.com/ipfs-shipyard/ipfs-companion/pull/824)

@yusefnapora  I also included `hashAlg` to be immune from changes to the default behavior of `ipfs add`, but feel free to remove it if you feel its an overkill. 