### PR TITLE
fix: label ipfs scheme URIs as "Address"

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Deploying this contract to the Ethereum mainnet is a bad idea since the contract
 
 Configuration are stored in [`./config/default.js`](./config/default.js).
 
-The `start-local-devnet.sh` script will try to run a local IPFS daemon, which Minty will connect to on its default port. If you've already installed IPFS and configured it to use a non-standard API port, you may need to change the `ipfsApiUrl` field to set the correct API address.
+The `./start-local-environment.sh` script will try to run a local IPFS daemon, which Minty will connect to on its default port. If you've already installed IPFS and configured it to use a non-standard API port, you may need to change the `ipfsApiUrl` field to set the correct API address.
 
 The `pinningService` configuration option is used by the `minty pin` command to persist
 IPFS data to a remote pinning service.

--- a/src/index.js
+++ b/src/index.js
@@ -86,9 +86,9 @@ async function createNFT(imagePath, options) {
 
     alignOutput([
         ['Token ID:', chalk.green(nft.tokenId)],
-        ['Metadata URI:', chalk.blue(nft.metadataURI)],
+        ['Metadata Address:', chalk.blue(nft.metadataURI)],
         ['Metadata Gateway URL:', chalk.blue(nft.metadataGatewayURL)],
-        ['Asset URI:', chalk.blue(nft.assetURI)],
+        ['Asset Address:', chalk.blue(nft.assetURI)],
         ['Asset Gateway URL:', chalk.blue(nft.assetGatewayURL)],
     ])
     console.log('NFT Metadata:')
@@ -108,9 +108,9 @@ async function getNFT(tokenId, options) {
         output.push(['Creator Address:', chalk.yellow(nft.creationInfo.creatorAddress)])
         output.push(['Block Number:', nft.creationInfo.blockNumber])
     }
-    output.push(['Metadata URI:', chalk.blue(nft.metadataURI)])
+    output.push(['Metadata Address:', chalk.blue(nft.metadataURI)])
     output.push(['Metadata Gateway URL:', chalk.blue(nft.metadataGatewayURL)])
-    output.push(['Asset URI:', chalk.blue(nft.assetURI)])
+    output.push(['Asset Address:', chalk.blue(nft.assetURI)])
     output.push(['Asset Gateway URL:', chalk.blue(nft.assetGatewayURL)])
     alignOutput(output)
 


### PR DESCRIPTION
Something doesn't sit right with calling ipfs:// scheme urls uris, and the canonical uri representation of an ipfs address as a uri is dweb:/ipfs/<cid>

To reduce future confusion, relabel the ipfs:// scheme urls to "Address"

Fixes #17 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>