### PR TITLE
Error: Cannot find module 'fs/promises'

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -1,4 +1,4 @@
-const fs = require('fs/promises')
+const fs = require("fs").promises
 const {F_OK} = require('fs')
 
 const inquirer = require('inquirer')

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
 // This file contains the main entry point for the command line `minty` app, and the command line option parsing code.
 // See minty.js for the core functionality.
 
-const fs = require('fs/promises')
 const path = require('path')
 const {Command} = require('commander')
 const inquirer = require('inquirer')

--- a/src/minty.js
+++ b/src/minty.js
@@ -1,4 +1,4 @@
-const fs = require('fs/promises')
+const fs = require("fs").promises
 const path = require('path')
 
 const CID = require('cids')


### PR DESCRIPTION
Fixes issue #22

Updated module imports

*  src/deploy.js
Updated fs promises import for Node 12+

* src/index.js
Removed unused promises import

* src/minty.js
Updated fs promises import for Node12+