### PR TITLE
Add EIP-173 Ownable interface

### DIFF
--- a/contracts/Minty.sol
+++ b/contracts/Minty.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.7.0;
 import "hardhat/console.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract Minty is ERC721 {
+contract Minty is ERC721, Ownable {
     using Counters for Counters.Counter;
     Counters.Counter private _tokenIds;
 
@@ -15,6 +16,7 @@ contract Minty is ERC721 {
 
     function mintToken(address owner, string memory metadataURI)
     public
+    onlyOwner
     returns (uint256)
     {
         _tokenIds.increment();


### PR DESCRIPTION
Prevents strangers from using the deployed contract to publish their own
NFTs.

Most NFT platforms today treat a contract as a publisher/collection, and
so by leaving a contract unrestricted, you also allow the
collection/publisher to be diluted. This might also work well as an
option.

Fixes #28