### PR TITLE
go-ipfs not needed to run daemon

### DIFF
--- a/start-local-environment.sh
+++ b/start-local-environment.sh
@@ -14,6 +14,6 @@ fi
 
 echo "Running IPFS and development blockchain"
 run_eth_cmd="npx hardhat node"
-run_ipfs_cmd="npx go-ipfs daemon"
+run_ipfs_cmd="ipfs daemon"
 
 npx concurrently -n eth,ipfs -c yellow,blue "$run_eth_cmd" "$run_ipfs_cmd"


### PR DESCRIPTION
#### Reference Issues/PRs
https://github.com/yusefnapora/minty/issues/19

#### What does this implement fix?
Removing go-ipfs from the bash-script allows the daemon to run. If we're trying to run go-ipfs we get the above-mentioned error msg. 
